### PR TITLE
scroll to section - bug fixed

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,8 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./about.css";
 import { MDBBtn, MDBIcon } from "mdb-react-ui-kit";
+import { useLocation } from 'react-router-dom';
 
 const About = () => {
+  const { hash } = useLocation();
+  const id = hash.replace('#', '');
+
+  useEffect(() => {
+    document.getElementById(id)?.scrollIntoView();
+  }, [ id ]);
+
   return (
     <div className="about-body">
       <div className="content">


### PR DESCRIPTION
Now, if you click on the teams link on the navbar from any page, it will go to the page and scoll to the correct section.