### PR TITLE
Fixed Filter Component Bug

### DIFF
--- a/src/components/SearchFilter/SearchFilter.js
+++ b/src/components/SearchFilter/SearchFilter.js
@@ -15,6 +15,7 @@ const SearchFilter = ({ fruits, filteredFruits, setFilteredFruits }) => {
 
   const handleGenusCriteria = (e) => {
     const value = e.target.value;
+    console.log(value);
     // Make a copy of the genusCriteria state array. Doing this because it is not best practice to directly mutate a state variable, so it makes sense to make a copy of it.
     // Modify that copy and then set the state variable to the copy using the setState() function.
     const genusCriteriaCopy = [...genusCriteria];
@@ -79,17 +80,14 @@ const SearchFilter = ({ fruits, filteredFruits, setFilteredFruits }) => {
       let filtered = [];
       if (genusCriteria.length > 0) {
         genusCriteria?.forEach((item) => {
-          filtered = [
-            ...filtered,
-            ...filteredFruits.filter((match) => match.genus.toLowerCase() === item),
-          ];
+          filtered = [...filtered, ...fruits.filter((match) => match.genus.toLowerCase() === item)];
         });
       }
       if (familyCriteria.length > 0) {
         familyCriteria?.forEach((item) => {
           filtered = [
             ...filtered,
-            ...filteredFruits.filter((match) => match.family.toLowerCase() === item),
+            ...fruits.filter((match) => match.family.toLowerCase() === item),
           ];
         });
       }


### PR DESCRIPTION
## Problem

The bug was causing the filter functionality to give unwanted results. For example, when a particular genus or family criteria is chosen, the filter operation is performed, but on selecting other criteria, the filter fails to work.

## Solution

The problem was that I was performing subsequent filters on the previous filter result instead of on the main fruits array state. Made the changes and boom, it finally worked.

Please feel free to test and report any other buy you may find. Thanks.